### PR TITLE
Update publisher and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- Open VSX Registry -->
 [![Open VSX Version](https://img.shields.io/open-vsx/v/SridharMocherla/bazel-kotlin-vscode-extension)](https://open-vsx.org/extension/SridharMocherla/bazel-kotlin-vscode-extension)
 
-This lightweight extension is used to "sync" the Bazel project with the Kotlin language server. This takes inspiration from the [Kotlin](https://github.com/fwcd/vscode-kotlin) extension but is focused on the [fork](https://github.com/smocherla-brex/kotlin-language-server-bazel-support) of the language server with bazel support. A lot of the implementation is based on the [Kotlin extension](https://github.com/fwcd/vscode-kotlin) but customized to support Bazel.
+This lightweight extension is used to "sync" the Bazel project with the Kotlin language server. This takes inspiration from the [Kotlin](https://github.com/fwcd/vscode-kotlin) extension but is focused on the [fork](https://github.com/brexhq/kotlin-language-server-bazel-support) of the language server with bazel support. A lot of the implementation is based on the [Kotlin extension](https://github.com/fwcd/vscode-kotlin) but customized to support Bazel.
 
 Additionally it also relies on a fork of [Kotlin Debug Adapter](https://github.com/fwcd/kotlin-debug-adapter) customized to support Bazel.
 
@@ -84,15 +84,15 @@ And then you can use the Debug console to launch and debug the bazel target.
 
 
 ## Example
-You can try the extension out on [this](https://github.com/smocherla-brex/bazel-kls-example) repo to find out how it works. For bzlmod, try out this [example](https://github.com/smocherla-brex/bazel-kls-bzlmod-example).
+You can try the extension out on [this](https://github.com/brexhq/bazel-kls-example) repo to find out how it works. For bzlmod, try out this [example](https://github.com/smocherla-brex/bazel-kls-bzlmod-example).
 
 ## Contributing
-Please check existing [Github issues](https://github.com/smocherla-brex/bazel-kotlin-vscode-extension/issues) if you have a feature request or a bug.
+Please check existing [Github issues](https://github.com/brexhq/bazel-kotlin-vscode-extension/issues) if you have a feature request or a bug.
 
 ### Development
 Working on changes scoped to just the extension should be fairly straightforward following the VSCode [guides](https://code.visualstudio.com/api/extension-guides/overview).
 
-If you're trying to integrate changes to the language server into the extension and test it end-to-end, please follow instructions [here](https://github.com/smocherla-brex/kotlin-language-server-bazel-support/blob/main/DEVELOPMENT.md).
+If you're trying to integrate changes to the language server into the extension and test it end-to-end, please follow instructions [here](https://github.com/brexhq/kotlin-language-server-bazel-support/blob/main/DEVELOPMENT.md).
 
 
 ## Relevant Configuration options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.4.2",
-  "publisher": "SridharMocherla",
+  "version": "0.5.0",
+  "publisher": "Brex",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/smocherla-brex/bazel-kotlin-vscode-extension.git"
+    "url": "https://github.com/brexhq/bazel-kotlin-vscode-extension.git"
   },
   "engines": {
     "vscode": "^1.94.0"

--- a/src/githubUtils.ts
+++ b/src/githubUtils.ts
@@ -169,7 +169,7 @@ export async function downloadLanguageServer(
   };
 
   const response = await fetch(
-    "https://api.github.com/repos/smocherla-brex/kotlin-language-server-bazel-support/releases",
+    "https://api.github.com/repos/brexhq/kotlin-language-server-bazel-support/releases",
     options
   );
   if (!response.ok) {
@@ -241,7 +241,7 @@ export async function downloadAspectReleaseArchive(
 
   // Get release info
   const response = await fetch(
-    `https://api.github.com/repos/smocherla-brex/${repo}/releases`,
+    `https://api.github.com/repos/brexhq/${repo}/releases`,
     options
   );
   if (!response.ok) {
@@ -312,7 +312,7 @@ export async function downloadDebugAdapter(
 
   // Get release info
   const response = await fetch(
-    `https://api.github.com/repos/smocherla-brex/${repo}/releases`,
+    `https://api.github.com/repos/brexhq/${repo}/releases`,
     options
   );
   if (!response.ok) {


### PR DESCRIPTION
Now that the repository is transferred, update the publisher and references accordingly. Also update minor version, I'll need a deprecation notice on a patch version bump with the old extension.

A follow-up is to add a deprecation notice in the old extension once a new version is published here.