### PR TITLE
Rename extension to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# bazel-kotlin-vscode-extension README
+# bazel-kotlin README
 <!-- VS Code Marketplace -->
-[![VS Code Marketplace Version](https://img.shields.io/badge/VS%20Code%20Marketplace-v0.4.2-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=SridharMocherla.bazel-kotlin-vscode-extension)
+[![VS Code Marketplace Version](https://img.shields.io/badge/VS%20Code%20Marketplace-v0.4.2-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=SridharMocherla.bazel-kotlin)
 
 <!-- Open VSX Registry -->
-[![Open VSX Version](https://img.shields.io/open-vsx/v/SridharMocherla/bazel-kotlin-vscode-extension)](https://open-vsx.org/extension/SridharMocherla/bazel-kotlin-vscode-extension)
+[![Open VSX Version](https://img.shields.io/open-vsx/v/SridharMocherla/bazel-kotlin)](https://open-vsx.org/extension/SridharMocherla/bazel-kotlin)
 
 This lightweight extension is used to "sync" the Bazel project with the Kotlin language server. This takes inspiration from the [Kotlin](https://github.com/fwcd/vscode-kotlin) extension but is focused on the [fork](https://github.com/brexhq/kotlin-language-server-bazel-support) of the language server with bazel support. A lot of the implementation is based on the [Kotlin extension](https://github.com/fwcd/vscode-kotlin) but customized to support Bazel.
 
@@ -87,7 +87,7 @@ And then you can use the Debug console to launch and debug the bazel target.
 You can try the extension out on [this](https://github.com/brexhq/bazel-kls-example) repo to find out how it works. For bzlmod, try out this [example](https://github.com/smocherla-brex/bazel-kls-bzlmod-example).
 
 ## Contributing
-Please check existing [Github issues](https://github.com/brexhq/bazel-kotlin-vscode-extension/issues) if you have a feature request or a bug.
+Please check existing [Github issues](https://github.com/brexhq/bazel-kotlin/issues) if you have a feature request or a bug.
 
 ### Development
 Working on changes scoped to just the extension should be fairly straightforward following the VSCode [guides](https://code.visualstudio.com/api/extension-guides/overview).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bazel-kotlin-vscode-extension",
+  "name": "bazel-kotlin",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bazel-kotlin-vscode-extension",
+      "name": "bazel-kotlin",
       "version": "0.5.0",
       "dependencies": {
         "@types/yauzl": "^2.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bazel-kotlin-vscode-extension",
-  "displayName": "bazel-kotlin-vscode-extension",
+  "name": "bazel-kotlin",
+  "displayName": "Bazel Kotlin",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
   "version": "0.5.0",
   "publisher": "Brex",
@@ -51,16 +51,16 @@
     ],
     "commands": [
       {
-        "command": "bazel-kotlin-vscode-extension.bazelSync",
+        "command": "bazel-kotlin.bazelSync",
         "title": "Bazel KLS sync"
       },
       {
-        "command": "bazel-kotlin-vscode-extension.clearCaches",
+        "command": "bazel-kotlin.clearCaches",
         "title": "Kotlin: Clear Language Server Caches",
         "category": "Kotlin"
       },
       {
-        "command": "bazel-kotlin-vscode-extension.stopBuild",
+        "command": "bazel-kotlin.stopBuild",
         "title": "Bazel KLS Sync: Stop Running Build",
         "icon": "$(stop)"
       }
@@ -132,7 +132,7 @@
     "menus": {
       "explorer/context": [
         {
-          "command": "bazel-kotlin-vscode-extension.bazelSync",
+          "command": "bazel-kotlin.bazelSync",
           "group": "inline",
           "when": "true"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Command for clearing caches
   const clearCaches = vscode.commands.registerCommand(
-    "bazel-kotlin-vscode-extension.clearCaches",
+    "bazel-kotlin.clearCaches",
     async () => {
       if (!context.storageUri) {
         return;
@@ -93,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Command to bazel "sync" the current package
   // Works on directories with build files
   const bazelSync = vscode.commands.registerCommand(
-    "bazel-kotlin-vscode-extension.bazelSync",
+    "bazel-kotlin.bazelSync",
     async (uri: vscode.Uri) => {
       // If no uri provided (command palette), use active editor
       if (!uri) {
@@ -321,13 +321,13 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   stopBuildButton.text = "$(stop) Stop Bazel KLS Sync";
-  stopBuildButton.command = "bazel-kotlin-vscode-extension.stopBuild";
+  stopBuildButton.command = "bazel-kotlin.stopBuild";
   stopBuildButton.tooltip = "Stop the current Bazel build";
   context.subscriptions.push(stopBuildButton);
 
   // Register stop build command
   const stopBuildCommand = vscode.commands.registerCommand(
-    "bazel-kotlin-vscode-extension.stopBuild",
+    "bazel-kotlin.stopBuild",
     async () => {
       if (currentBazelProcess && isBuildRunning && currentBazelProcess.pid) {
         outputChannel.appendLine("Stopping Bazel build process...");
@@ -417,7 +417,7 @@ async function downloadAspectRelease(
     },
     async (progress) => {
       await downloadAspectReleaseArchive(
-        "bazel-kotlin-vscode-extension",
+        "bazel-kotlin",
         ASPECT_RELEASE_VERSION,
         sourcesPath,
         progress

--- a/src/githubUtils.ts
+++ b/src/githubUtils.ts
@@ -38,7 +38,7 @@ async function downloadFile(
 ): Promise<Buffer> {
   const options = {
     headers: {
-      "User-Agent": "bazel-kotlin-vscode-extension",
+      "User-Agent": "bazel-kotlin",
       ...additionalHeaders,
     },
   };


### PR DESCRIPTION
Even though publisher ID is unique, VScode complains about the existing extension. Rename the extension to avoid this publishing error.