### PR TITLE
Rename config namespace to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Note that your test runner needs to support `--test_filter` to run single tests 
 
 In the original implementation, the LSP would try to compile all the source files in the workspace to compute the module descriptors and the PSI represenation of the source files. In a large repo involving thousands of source files, this may lead to very high resource usage and the initial sync could be significantly slow. With our bazel sync implementation, we pre-compute a lot of things in the `bazel build` through an aspect, so it becomes redundant to do so again in the LSP for all files. So we can opt to just do "lazy" compliation but still get the full symbol index through the classpath from the build. The lazy/on-demand compilation mode is enabled by default. It can be disabled with the following configuration option:
 ```
-bazelKLS.lazyCompilation: false
+bazelKotlin.lazyCompilation: false
 ```
 
 When lazy compilation is enabled, the LSP will only compile the files that are open initially. When symbols in other files are referenced through `Go-to-definition`, compilation of those files is triggered so as to support navigation. The LSP will still index all the symbols globally after the first Bazel sync, so you still get the benefits of completions and quick fixes even though we don't compile everything. 
@@ -53,7 +53,7 @@ You can now debug using a customized implementation of [Kotlin Debug Adapter](ht
 
 First enable the debug adapter with
 ```
-bazelKLS.debugAdapter.enabled: true
+bazelKotlin.debugAdapter.enabled: true
 ```
 
 and reload VSCode. It should download the debug adapter and activate it. Then you can create a launch configuration which will be something like
@@ -97,9 +97,9 @@ If you're trying to integrate changes to the language server into the extension 
 
 ## Relevant Configuration options
 
-- `bazelKLS.enabled`: Whether to enable the language server.
-- `bazelKLS.jvmOpts`: The JVM options to use when starting the language server.
-- `bazelKLS.buildFlags`: The bazel flags to be passed to the `bazel build` command during a sync.
-- `bazelKLS.debugAdapter.enabled`: Whether to enable the debug adapter or not.
-- `bazelKLS.lazyCompilation`: Whether to enable lazy/on-demand compilation.
+- `bazelKotlin.enabled`: Whether to enable the language server.
+- `bazelKotlin.jvmOpts`: The JVM options to use when starting the language server.
+- `bazelKotlin.buildFlags`: The bazel flags to be passed to the `bazel build` command during a sync.
+- `bazelKotlin.debugAdapter.enabled`: Whether to enable the debug adapter or not.
+- `bazelKotlin.lazyCompilation`: Whether to enable lazy/on-demand compilation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "views": {
       "test": [
         {
-          "id": "kotestTests",
+          "id": "bazelKotlin.kotestTests",
           "name": "Kotest Tests"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin",
   "displayName": "Bazel Kotlin",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publisher": "Brex",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {
@@ -141,31 +141,31 @@
     "configuration": {
       "title": "Bazel KLS Sync",
       "properties": {
-        "bazelKLS.enabled": {
+        "bazelKotlin.enabled": {
           "type": "boolean",
           "default": true
         },
-        "bazelKLS.languageServerVersion": {
+        "bazelKotlin.languageServerVersion": {
           "type": "string",
           "default": "v1.6.3-bazel"
         },
-        "bazelKLS.jvmOpts": {
+        "bazelKotlin.jvmOpts": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": []
         },
-        "bazelKLS.aspectPath": {
+        "bazelKotlin.aspectPath": {
           "type": "string",
           "description": "Optionally a custom path to the aspect workspace used by the LSP. If not provided, the extension will download the latest aspect release from Github. Typically used for iterating on the aspect."
         },
-        "bazelKLS.path": {
+        "bazelKotlin.path": {
           "type": "string",
           "default": "",
           "description": "Optionally a custom path to the language server executable."
         },
-        "bazelKLS.transport": {
+        "bazelKotlin.transport": {
           "type": "string",
           "enum": [
             "stdio",
@@ -174,32 +174,32 @@
           "description": "The transport layer beneath the language server protocol. Note that the extension will launch the server even if a TCP socket is used.",
           "default": "stdio"
         },
-        "bazelKLS.port": {
+        "bazelKotlin.port": {
           "type": "integer",
           "description": "The port to which the client will attempt to connect to. A random port is used if zero. Only used if the transport layer is TCP.",
           "default": 0
         },
-        "bazelKLS.debugAttach.enabled": {
+        "bazelKotlin.debugAttach.enabled": {
           "type": "boolean",
           "description": "[DEBUG] Whether the language server should listen for debuggers, i.e. be debuggable while running in VSCode. This is ONLY useful if you need to debug the language server ITSELF.",
           "default": false
         },
-        "bazelKLS.debugAttach.port": {
+        "bazelKotlin.debugAttach.port": {
           "type": "integer",
           "description": "[DEBUG] If transport is stdio this enables you to attach to the running language server with a debugger. This is ONLY useful if you need to debug the language server ITSELF.",
           "default": 5009
         },
-        "bazelKLS.debugAttach.autoSuspend": {
+        "bazelKotlin.debugAttach.autoSuspend": {
           "type": "boolean",
           "description": "[DEBUG] If enabled (together with debugAttach.enabled), the language server will not immediately launch but instead listen on the specified attach port and wait for a debugger. This is ONLY useful if you need to debug the language server ITSELF.",
           "default": false
         },
-        "bazelKLS.lazyCompilation": {
+        "bazelKotlin.lazyCompilation": {
           "type": "boolean",
           "default": true,
           "description": "Enables lazy compilation, meaning source files will either be compiled only on-demand (indirectly referenced through other symbols) or when opened explicitly. This is helpful to improve performance in a large repository."
         },
-        "bazelKLS.watchFiles": {
+        "bazelKotlin.watchFiles": {
           "type": "array",
           "default": [
             "**/*.kt",
@@ -211,7 +211,7 @@
           ],
           "description": "Specifies glob patterns of files, which would be watched by LSP client. The LSP client doesn't support watching files outside a workspace folder."
         },
-        "bazelKLS.trace.server": {
+        "bazelKotlin.trace.server": {
           "type": "string",
           "enum": [
             "off",
@@ -222,17 +222,17 @@
           "description": "Traces the communication between VSCode and the Kotlin language server.",
           "scope": "window"
         },
-        "bazelKLS.jvmTarget": {
+        "bazelKotlin.jvmTarget": {
           "type": "string",
           "default": "11",
           "description": "Specifies the JVM target, e.g. '11' or '17'."
         },
-        "bazelKLS.diagnostics.enabled": {
+        "bazelKotlin.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Whether diagnostics (e.g. errors or warnings from the Kotlin compiler) should be emitted."
         },
-        "bazelKLS.diagnostics.level": {
+        "bazelKotlin.diagnostics.level": {
           "type": "string",
           "default": "hint",
           "enum": [
@@ -243,84 +243,84 @@
           ],
           "description": "The minimum severity of diagnostics to emit."
         },
-        "bazelKLS.diagnostics.debounceTime": {
+        "bazelKotlin.diagnostics.debounceTime": {
           "type": "integer",
           "default": 250,
           "description": "[DEBUG] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possible stability issues."
         },
-        "bazelKLS.linting.debounceTime": {
+        "bazelKotlin.linting.debounceTime": {
           "type": "integer",
           "default": 250,
-          "deprecationMessage": "The option has been renamed to `bazelKLS.diagnostics.debounceTime`",
+          "deprecationMessage": "The option has been renamed to `bazelKotlin.diagnostics.debounceTime`",
           "description": "[DEBUG] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possible stability issues."
         },
-        "bazelKLS.scripts.buildScriptsEnabled": {
+        "bazelKotlin.scripts.buildScriptsEnabled": {
           "type": "boolean",
           "default": false,
           "description": "Whether language features are provided for .gradle.kts scripts. Experimental and may not work properly."
         },
-        "bazelKLS.indexing.enabled": {
+        "bazelKotlin.indexing.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Whether global symbols in the project should be indexed automatically in the background. This enables e.g. code completion for unimported classes and functions."
         },
-        "bazelKLS.completion.snippets.enabled": {
+        "bazelKotlin.completion.snippets.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Specifies whether code completion should provide snippets (true) or plain-text items (false)."
         },
-        "bazelKLS.debugAdapter.enabled": {
+        "bazelKotlin.debugAdapter.enabled": {
           "type": "boolean",
           "default": false,
           "description": "[Recommended] Specifies whether the debug adapter should be used. When enabled a debugger for Kotlin will be available."
         },
-        "bazelKLS.debugAdapter.version": {
+        "bazelKotlin.debugAdapter.version": {
           "type": "string",
           "default": "v1.6.3-bazel",
           "description": "The debug adapter version from Github releases"
         },
-        "bazelKLS.debugAdapter.path": {
+        "bazelKotlin.debugAdapter.path": {
           "type": "string",
           "description": "Optionally a custom path to the debug adapter executable."
         },
-        "bazelKLS.debounceTime": {
+        "bazelKotlin.debounceTime": {
           "type": "integer",
           "default": 250,
           "description": "[DEPRECATED] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possible stability issues.",
-          "deprecationMessage": "Use 'bazelKLS.linting.debounceTime' instead"
+          "deprecationMessage": "Use 'bazelKotlin.linting.debounceTime' instead"
         },
-        "bazelKLS.externalSources.useKlsScheme": {
+        "bazelKotlin.externalSources.useKlsScheme": {
           "type": "boolean",
           "default": true,
           "description": "[Recommended] Specifies whether URIs inside JARs should be represented using the 'kls'-scheme."
         },
-        "bazelKLS.externalSources.autoConvertToKotlin": {
+        "bazelKotlin.externalSources.autoConvertToKotlin": {
           "type": "boolean",
           "default": false,
           "description": "Specifies whether decompiled/external classes should be auto-converted to Kotlin."
         },
-        "bazelKLS.snippetsEnabled": {
+        "bazelKotlin.snippetsEnabled": {
           "type": "boolean",
           "default": true,
           "description": "[DEPRECATED] Specifies whether code completion should provide snippets (true) or plain-text items (false).",
-          "deprecationMessage": "Use 'bazelKLS.completion.snippets.enabled'"
+          "deprecationMessage": "Use 'bazelKotlin.completion.snippets.enabled'"
         },
-        "bazelKLS.inlayHints.typeHints": {
+        "bazelKotlin.inlayHints.typeHints": {
           "type": "boolean",
           "default": false,
           "description": "Whether to provide inlay hints for types on declaration sites or not."
         },
-        "bazelKLS.inlayHints.parameterHints": {
+        "bazelKotlin.inlayHints.parameterHints": {
           "type": "boolean",
           "default": false,
           "description": "Whether to provide inlay hints for parameters on call sites or not."
         },
-        "bazelKLS.inlayHints.chainedHints": {
+        "bazelKotlin.inlayHints.chainedHints": {
           "type": "boolean",
           "default": false,
           "description": "Whether to provide inlay hints on chained function calls or not."
         },
-        "bazelKLS.buildFlags" : {
+        "bazelKotlin.buildFlags" : {
           "type": "array",
           "default": [],
           "description": "A list of build flags to be passed to the bazel build command during a sync."

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export interface BazelKotlinDebugAdapterConfig {
 }
 
 export class ConfigurationManager {
-    private static readonly SECTION = 'bazelKLS';
+    private static readonly SECTION = 'bazelKotlin';
     private languageServerInstallPath: string;
     private config: vscode.WorkspaceConfiguration;
     private aspectSourcesPath: string;

--- a/src/kotest.ts
+++ b/src/kotest.ts
@@ -25,7 +25,7 @@ export class KotestTestController {
     private kotlinClient: any;
 
     constructor() {
-        this.testController = vscode.tests.createTestController('kotestTests', 'Kotest Tests');
+        this.testController = vscode.tests.createTestController('bazelKotlin.kotestTests', 'Kotest Tests');
         this.testController.createRunProfile('Run', vscode.TestRunProfileKind.Run, this.runTests.bind(this));
     }
 

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -143,7 +143,7 @@ export class KotlinLanguageClient {
 
     // Create and start the language client
     this.client = new LanguageClient(
-      "bazelKLS",
+      "bazelKotlin",
       "Bazel KLS",
       serverOptions,
       clientOptions

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -12,7 +12,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         storageUri: vscode.Uri.parse('vscode-test-uri'),
         globalStoragePath: '/path/to/global/storage',
         extension: {
-            id: 'bazelKLS',
+            id: 'bazelKotlin',
             extensionUri: vscode.Uri.parse('vscode-test-uri'),
             extensionPath: '/path/to/extension',
             isActive: true,
@@ -20,7 +20,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
             exports: {},
             activate: sinon.stub(),
             packageJSON: {
-                name: 'bazelKLS',
+                name: 'bazelKotlin',
                 version: '1.0.0',
                 engines: {
                     vscode: '1.0.0'
@@ -82,7 +82,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
     // Teardown: clean up any test-specific configurations
     teardown(async () => {
         // Reset any settings changed during testing
-        await vscode.workspace.getConfiguration('bazelKLS').update('enabled', undefined, vscode.ConfigurationTarget.Global);
+        await vscode.workspace.getConfiguration('bazelKotlin').update('enabled', undefined, vscode.ConfigurationTarget.Global);
         await vscode.workspace.getConfiguration('bazelKLS').update('jvmTarget', undefined, vscode.ConfigurationTarget.Global);
         await vscode.workspace.getConfiguration('bazelKLS').update('jvmOpts', undefined, vscode.ConfigurationTarget.Global);
         await vscode.workspace.getConfiguration('bazelKLS').update('buildFlags', undefined, vscode.ConfigurationTarget.Global);


### PR DESCRIPTION
The config settings also conflict with the existing extension, so rename it to `bazelKotlin` to avoid conflict while activating extension. Will test this locally