### PR TITLE
Support ktlint as formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
         },
         "bazelKLS.jvmTarget": {
           "type": "string",
-          "default": "11",
+          "default": "17",
           "description": "Specifies the JVM target, e.g. '11' or '17'."
         },
         "bazelKLS.diagnostics.enabled": {
@@ -324,6 +324,22 @@
           "type": "array",
           "default": [],
           "description": "A list of build flags to be passed to the bazel build command during a sync."
+        },
+        "bazelKLS.formatter": {
+          "type": "string",
+          "enum": ["ktlint", "ktfmt", "off"],
+          "default": "off",
+          "description": "Formatter to use for Kotlin files."
+        },
+        "bazelKLS.ktlint.ktlintPath": {
+          "type": "string",
+          "default": "ktlint",
+          "description": "Path to the ktlint binary. Only used when formatter is set to 'ktlint'."
+        },
+        "bazelKLS.ktlint.editorConfigPath": {
+          "type": "string",
+          "default": ".editorconfig",
+          "description": "Path to the .editorconfig file used by ktlint. Only used when formatter is set to 'ktlint'."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,18 @@ export interface BazelKLSConfig {
     buildFlags: string[];
     debugAdapter: BazelKotlinDebugAdapterConfig,
     lazyCompilation: boolean
+    formatterConfig: BazelKotlinFormatterConfig,
+}
+
+export interface BazelKotlinFormatterConfig {
+    formatter: "ktlint" | "ktfmt" | "off";
+    ktlint?: KtlintConfig;
+}
+
+export interface KtlintConfig {
+    enabled: boolean;
+    ktlintPath: string;
+    editorConfigPath: string;
 }
 
 export interface BazelKotlinDebugAdapterConfig {
@@ -45,7 +57,7 @@ export class ConfigurationManager {
     getConfig(): BazelKLSConfig {
         return {
                 enabled: this.config.get('enabled', true),
-                jvmTarget: this.config.get('jvmTarget', '11'),
+                jvmTarget: this.config.get('jvmTarget', '17'),
                 jvmOpts: this.config.get('jvmOpts', []),
                 languageServerInstallPath: this.languageServerInstallPath,
                 languageServerVersion: this.config.get('languageServerVersion', 'v1.6.3-bazel'),
@@ -62,6 +74,14 @@ export class ConfigurationManager {
                     version: this.config.get('debugAdapter.version', 'v1.6.3-bazel'),
                 },
                 lazyCompilation: this.config.get('lazyCompilation', false),
+                formatterConfig: {
+                    formatter: this.config.get('formatter', 'off'),
+                    ktlint: {
+                        enabled: this.config.get('ktlint.ktlintPath') !== undefined,
+                        ktlintPath: this.config.get('ktlint.ktlintPath', 'ktlint'),
+                        editorConfigPath: this.config.get('ktlint.editorConfigPath', '.editorconfig')
+                    }
+                }
         };
     }
 

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -108,7 +108,7 @@ export class KotlinLanguageClient {
       options.outputChannel.appendLine(
         `Attaching debugger to language server on port ${config.debugAttachPort}`
       );
-      env.KOTLIN_LANGUAGE_SERVER_OPTS = `-Xdebug -agentlib:jdwp=transport=dt_socket,address=${config.debugAttachPort},server=y,quiet=y,suspend=n`;
+      env.KOTLIN_LANGUAGE_SERVER_OPTS = `-Xdebug -agentlib:jdwp=transport=dt_socket,address=${config.debugAttachPort},server=y,quiet=y,suspend=y`;
     }
 
     // Server options - configure the Kotlin Language Server executable
@@ -135,6 +135,13 @@ export class KotlinLanguageClient {
       initializationOptions: {
         storagePath: this.context.storageUri?.fsPath,
         lazyCompilation: config.lazyCompilation,
+        formattingConfiguration: {
+          formatter: config.formatterConfig.formatter,
+          ktlint: {
+            ktlintPath: config.formatterConfig.ktlint?.ktlintPath,
+            editorConfigPath: config.formatterConfig.ktlint?.editorConfigPath
+          }
+        }
       },
       outputChannel: options.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -93,7 +93,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         console.log(config);
         
         assert.strictEqual(config.enabled, true);
-        assert.strictEqual(config.jvmTarget, '11');
+        assert.strictEqual(config.jvmTarget, '17');
         assert.deepStrictEqual(config.jvmOpts, []);
         assert.strictEqual(config.languageServerVersion, 'v1.6.3-bazel');
         assert.strictEqual(config.javaHome, '');
@@ -118,7 +118,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         // Update settings
         await configManager.update({
                 enabled: false,
-                jvmTarget: '17',
+                jvmTarget: '11',
                 jvmOpts: ['-Xmx2g'],
                 buildFlags: ["--config=remote"],
                 lazyCompilation: true,
@@ -131,7 +131,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         
         // Verify settings were updated
         assert.strictEqual(updatedConfig.enabled, false);
-        assert.strictEqual(updatedConfig.jvmTarget, '17');
+        assert.strictEqual(updatedConfig.jvmTarget, '11');
         assert.deepStrictEqual(updatedConfig.jvmOpts, ['-Xmx2g']);
         assert.strictEqual(updatedConfig.buildFlags.length, 1);
         assert.deepEqual(updatedConfig.buildFlags, ["--config=remote"]);


### PR DESCRIPTION
Addresses #44 

This adds ktlint as a formatter that's supported with the LSP.

ktlint can format and also lint. This PR also adds the formatting changes that go in tandem with https://github.com/brexhq/kotlin-language-server-bazel-support/pull/52

A follow-up is to add it as a linter with diagnostics - that's a bit more involved